### PR TITLE
Force screen resizing on terminal resize

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,3 +1,8 @@
+#ifndef _WIN32
+# include <sys/ioctl.h>
+# include <termios.h>
+#endif
+
 #include <cstdlib>
 #include <cstring>
 #include "io.h"
@@ -146,6 +151,14 @@ void deinit_curses()
 bool update_reso()
 {
 	int oldr = row, oldc = col;
+
+#ifndef _WIN32
+	struct winsize ws;
+
+	ioctl(0, TIOCGWINSZ, &ws);
+	resize_term(ws.ws_row, ws.ws_col);
+#endif
+
 	refresh();
 	getmaxyx(stdscr, row, col);
 


### PR DESCRIPTION
I don't know why, but curses doesn't get new terminal size automatically, at least not always. This fixes it.
